### PR TITLE
#2 - Ignore dev files in npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,6 @@
+.babelrc
+.eslintignore
+.eslintrc
+.gitignore
+.travis.yml
 src/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "name": "future-state",
   "description": "Subscribe to future values in a Redux store.",
   "main": "lib/index.js",


### PR DESCRIPTION
These files are not needed when pulling from npm, just for development.